### PR TITLE
fix: end waitForPeers timer on closed channel

### DIFF
--- a/src/wait-for-peers.js
+++ b/src/wait-for-peers.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const waitForPeers = async (ipfs, peersToWait, topic) => {
+const waitForPeers = async (ipfs, peersToWait, topic, isClosed) => {
   const checkPeers = async () => {
     const peers = await ipfs.pubsub.peers(topic)
     const hasAllPeers = peersToWait.map((e) => peers.includes(e)).filter((e) => e === false).length === 0
@@ -14,7 +14,7 @@ const waitForPeers = async (ipfs, peersToWait, topic) => {
   return new Promise(async (resolve, reject) => {
     const interval = setInterval(async () => {
       try {
-        if (await checkPeers()) {
+        if (isClosed() || await checkPeers()) {
           clearInterval(interval)
           resolve()
         }

--- a/test/direct-channel.test.js
+++ b/test/direct-channel.test.js
@@ -4,7 +4,7 @@ const path = require('path')
 const rmrf = require('rimraf')
 const assert = require('assert')
 const pMapSeries = require('p-map-series')
-const { 
+const {
   createIpfsTestInstances,
   destroyIpfsTestInstances,
   connectIpfsInstances,
@@ -243,7 +243,7 @@ describe('DirectChannel', function() {
   })
 
   describe('non-participant peers can\'t send messages', function() {
-    it('doesn\'t receive unwated messages', async () => {
+    it('doesn\'t receive unwanted messages', async () => {
       const c1 = await Channel.open(ipfs1, id2)
       const c2 = await Channel.open(ipfs2, id1)
 
@@ -259,7 +259,7 @@ describe('DirectChannel', function() {
       })
 
       await ipfs3.pubsub.subscribe(c1.id, () => {})
-      await waitForPeers(ipfs1, [id3], c1.id)
+      await waitForPeers(ipfs1, [id3], c1.id, c1._isClosed.bind(c1))
       await ipfs3.pubsub.publish(c1.id, Buffer.from('OMG!'))
 
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
I've noticed that some of my tests hang because of the waitForPeers timer is not resolving.

I believe what is happening is a test spins up two nodes, node1 resolves and closes the connection before node2 resolves, thus leaving node2 waiting for peers. The timer on node2 continues to run when the test ends and the channels are closed.

I've added a check in the timer to see if the channel has been closed to clear the timer.