### PR TITLE
Fix/wait for peers

### DIFF
--- a/src/wait-for-peers.js
+++ b/src/wait-for-peers.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const waitForPeers = async (ipfs, peersToWait, topic) => {
+const waitForPeers = async (ipfs, peersToWait, topic, isClosed) => {
   const checkPeers = async () => {
     const peers = await ipfs.pubsub.peers(topic)
     const hasAllPeers = peersToWait.map((e) => peers.includes(e)).filter((e) => e === false).length === 0
@@ -14,7 +14,7 @@ const waitForPeers = async (ipfs, peersToWait, topic) => {
   return new Promise(async (resolve, reject) => {
     const interval = setInterval(async () => {
       try {
-        if (await checkPeers()) {
+        if (isClosed() || await checkPeers()) {
           clearInterval(interval)
           resolve()
         }

--- a/src/wait-for-peers.js
+++ b/src/wait-for-peers.js
@@ -14,7 +14,9 @@ const waitForPeers = async (ipfs, peersToWait, topic, isClosed) => {
   return new Promise(async (resolve, reject) => {
     const interval = setInterval(async () => {
       try {
-        if (isClosed() || await checkPeers()) {
+        if (isClosed()) {
+          clearInterval(interval)
+        } else if (await checkPeers()) {
           clearInterval(interval)
           resolve()
         }

--- a/test/direct-channel.test.js
+++ b/test/direct-channel.test.js
@@ -194,13 +194,21 @@ Object.keys(testAPIs).forEach(API => {
         await c2.connect()
 
         return new Promise(async (resolve, reject) => {
+          assert.equal(c1._closed, false)
+          assert.equal(c1._isClosed(), false)
           c1.close()
           const topics1 = await ipfs1.pubsub.ls()
           assert.deepEqual(topics1, [])
+          assert.equal(c1._closed, true)
+          assert.equal(c1._isClosed(), true)
 
+          assert.equal(c2._closed, false)
+          assert.equal(c2._isClosed(), false)
           c2.close()
           const topics2 = await ipfs2.pubsub.ls()
           assert.deepEqual(topics1, [])
+          assert.equal(c2._closed, true)
+          assert.equal(c2._isClosed(), true)
 
           setTimeout(async () => {
             const peers1 = await ipfs1.pubsub.peers(c1.id)

--- a/test/direct-channel.test.js
+++ b/test/direct-channel.test.js
@@ -253,7 +253,7 @@ Object.keys(testAPIs).forEach(API => {
     })
 
     describe('non-participant peers can\'t send messages', function() {
-      it('doesn\'t receive unwated messages', async () => {
+      it('doesn\'t receive unwanted messages', async () => {
         const c1 = await Channel.open(ipfs1, id2)
         const c2 = await Channel.open(ipfs2, id1)
 
@@ -269,7 +269,7 @@ Object.keys(testAPIs).forEach(API => {
         })
 
         await ipfs3.pubsub.subscribe(c1.id, () => {})
-        await waitForPeers(ipfs1, [id3], c1.id)
+        await waitForPeers(ipfs1, [id3], c1.id, c1._isClosed.bind(c1))
         await ipfs3.pubsub.publish(c1.id, Buffer.from('OMG!'))
 
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
Builds on #10

- rebased to latest
- separated waitForPeers interval being closed, by channel being closed and peers being found. this is so waitForPeers doesnt resolve when the peers havent actually been found.
- added tests for closed state variables. the tests arent as verbose as would be nice but its safe to assume the interval is being cleared now.


Closes #10 
Closes #28
Fixes orbitdb/orbit-db#947