### PR TITLE
fix: Ensure peer addresses are being used when checking if all peers are connected.

### DIFF
--- a/src/direct-channel.js
+++ b/src/direct-channel.js
@@ -82,7 +82,7 @@ class DirectChannel extends EventEmitter {
     // Function to use to handle incoming messages
     this._messageHandler = message => {
       // Make sure the message is coming from the correct peer
-      const isValid = message && message.from === this._receiverID
+      const isValid = message && String(message.from) === String(this._receiverID)
       // Filter out all messages that didn't come from the second peer
       if (isValid) {
         this.emit('message', message)

--- a/src/wait-for-peers.js
+++ b/src/wait-for-peers.js
@@ -3,7 +3,7 @@
 const waitForPeers = async (ipfs, peersToWait, topic, isClosed) => {
   const checkPeers = async () => {
     const peers = await ipfs.pubsub.peers(topic)
-    const hasAllPeers = peersToWait.map((e) => peers.includes(e)).filter((e) => e === false).length === 0
+    const hasAllPeers = peersToWait.map(e => String(e)).map((e) => peers.map(e => String(e)).includes(e)).filter((e) => e === false).length === 0
     return hasAllPeers
   }
 

--- a/src/wait-for-peers.js
+++ b/src/wait-for-peers.js
@@ -3,7 +3,9 @@
 const waitForPeers = async (ipfs, peersToWait, topic, isClosed) => {
   const checkPeers = async () => {
     const peers = await ipfs.pubsub.peers(topic)
-    const hasAllPeers = peersToWait.map(e => String(e)).map((e) => peers.map(e => String(e)).includes(e)).filter((e) => e === false).length === 0
+    const idPeersToWait = peersToWait.map(e => String(e))
+    const idPeers = peers.map(e => String(e))
+    const hasAllPeers = idPeersToWait.map((e) => idPeers.includes(e)).filter((e) => e === false).length === 0
     return hasAllPeers
   }
 


### PR DESCRIPTION
Checking for peers who are subscribed to direct connection messages is failing because peers cannot be filtered by object. Instead, convert the peer to its address and then check it against the subscription list.